### PR TITLE
Multiblock tweaks/fixes

### DIFF
--- a/src/main/java/sunsetsatellite/signalindustries/gui/guidebook/SignalIndustriesSection.java
+++ b/src/main/java/sunsetsatellite/signalindustries/gui/guidebook/SignalIndustriesSection.java
@@ -80,9 +80,11 @@ public class SignalIndustriesSection extends SearchableGuidebookSection {
         subsections.add(multiblocks);
     }
 
+    boolean filtered = false;
     public void reloadSection(){
         pages.clear();
-        pages.add(new IntroPage(this,"guidebook.section.signalindustries.intro"));
+        if (!filtered) pages.add(new IntroPage(this,"guidebook.section.signalindustries.intro"));
+        filtered = false;
     }
 
     @Override
@@ -109,6 +111,8 @@ public class SignalIndustriesSection extends SearchableGuidebookSection {
 
     @Override
     public List<GuidebookPage> searchPages(SearchQuery query) {
+        filtered = true;
+        reloadSection();
         ArrayList<GuidebookPage> list = new ArrayList<>(pages);
         for (SearchableGuidebookSubsection subsection : subsections) {
             List<GuidebookPage> searchList = subsection.searchPages(query);

--- a/src/main/java/sunsetsatellite/signalindustries/gui/guidebook/pages/MultiblockMaterialsPage.java
+++ b/src/main/java/sunsetsatellite/signalindustries/gui/guidebook/pages/MultiblockMaterialsPage.java
@@ -57,7 +57,20 @@ public class MultiblockMaterialsPage extends GuidebookPage {
                 .map((B) -> new ItemStack(B.block, 1, B.meta == -1 ? 0 : B.meta))
                 .collect(Collectors.toList());
         List<ItemStack> blocks = SignalIndustries.condenseList(blocksUncondensed);
-        blocks.add(new ItemStack(multiblock.getOrigin().block,1, multiblock.getOrigin().meta == -1 ? 0 : multiblock.getOrigin().meta));
+        ItemStack origin = new ItemStack(multiblock.getOrigin().block,1, multiblock.getOrigin().meta == -1 ? 0 : multiblock.getOrigin().meta);
+
+        // Annoying special case for when the origin isn't that special
+        boolean matched = false;
+        for (ItemStack is : blocks) {
+            if (origin.isItemEqual(is)) {
+                is.stackSize += 1;
+                matched = true;
+                break;
+            }
+        }
+        if (!matched) {
+            blocks.add(origin);
+        }
 
         int i = 0;
         int maxSlotsInRow = 7;

--- a/src/main/java/sunsetsatellite/signalindustries/gui/guidebook/sections/MultiblockSection.java
+++ b/src/main/java/sunsetsatellite/signalindustries/gui/guidebook/sections/MultiblockSection.java
@@ -33,6 +33,7 @@ public class MultiblockSection extends SearchableGuidebookSubsection {
         List<Field> multiblockFields = Arrays.stream(SIMultiblocks.class.getDeclaredFields()).filter((F) -> SIMultiblock.class.isAssignableFrom(F.getType())).collect(Collectors.toList());
         try {
             for (Field field : multiblockFields) {
+                field.setAccessible(true);
                 pages.add(new MultiblockPage(parent, (Multiblock) field.get(null)));
                 pages.add(new MultiblockMaterialsPage(parent, (Multiblock) field.get(null)));
             }

--- a/src/main/java/sunsetsatellite/signalindustries/mixin/PlayerControllerMixin.java
+++ b/src/main/java/sunsetsatellite/signalindustries/mixin/PlayerControllerMixin.java
@@ -3,12 +3,15 @@ package sunsetsatellite.signalindustries.mixin;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.controller.PlayerController;
 import net.minecraft.core.entity.player.EntityPlayer;
+import net.minecraft.core.item.tag.ItemTags;
 import net.minecraft.core.util.helper.Side;
+import net.minecraft.core.item.ItemStack;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import sunsetsatellite.catalyst.core.util.Vec3i;
 import sunsetsatellite.signalindustries.commands.StructMakerCommand;
@@ -20,7 +23,17 @@ public class PlayerControllerMixin {
     @Inject(method = "destroyBlock", at = @At(value = "INVOKE", shift = At.Shift.BEFORE, target = "Lnet/minecraft/core/world/World;playSoundEffect(IIIII)V"))
     public void destroyBlock(int x, int y, int z, Side side, EntityPlayer player, CallbackInfoReturnable<Boolean> cir) {
         if(StructMakerCommand.autoAddRemove){
-            StructMakerCommand.internalRemoveBlock(mc, new Vec3i(x,y,z));
+            StructMakerCommand.internalRemoveBlock(mc, mc.theWorld, new Vec3i(x,y,z));
+        }
+    }
+
+    @Inject(method = "startDestroyBlock", at = @At(value = "INVOKE", shift = At.Shift.AFTER, target = "getCurrentEquippedItem"))
+    public void startDestroyBlock(int x, int y, int z, Side side, double xHit, double yHit, boolean repeat, CallbackInfo ci) {
+        ItemStack heldItem = this.mc.thePlayer.getCurrentEquippedItem();
+        if (heldItem != null && heldItem.getItem().hasTag(ItemTags.PREVENT_CREATIVE_MINING)) {
+            if(StructMakerCommand.autoAddRemove){
+                StructMakerCommand.internalAddBlock(mc, new Vec3i(x, y, z));
+            }
         }
     }
 }


### PR DESCRIPTION
- Allow vanilla blocks (by default) and blocks from other mods (with a command) to be used in structures saved by `/s`
- Fix `/s auto` and `/s add` on the origin saving the same block twice at the same place
- Fix `/s save` mangling the filename on non-windows systems
- Allow hitting blocks with a sword to add them when using `/s auto` (good for pre-existing structures)
- Make the guidebook not show the intro page when searching
- Fix the guidebook multiblock material page showing two diffrent stacks when the origin is also one of the blocks
- Fix minor crash that occurs when using an extra mod to add a new multiblock to SI (the mixin'd feild cannot be public and static, so it has to be private and static, which requires `setAccessible`)
